### PR TITLE
fix: update idna to resolve CVE-2026-45409

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -32,7 +32,7 @@ httpx==0.28.1
     # via
     #   oz-agent-sdk
     #   respx
-idna==3.11
+idna==3.17
     # via
     #   anyio
     #   httpx

--- a/uv.lock
+++ b/uv.lock
@@ -470,11 +470,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -779,7 +779,7 @@ wheels = [
 
 [[package]]
 name = "oz-agent-sdk"
-version = "0.4.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- Updates transitive runtime dependency `idna` from `3.11` to `3.17` via `uv lock --upgrade-package idna`
- Regenerates `requirements-dev.lock` with the updated pin
- Resolves Dependabot alert: https://github.com/warpdotdev/oz-sdk-python/security/dependabot/13

## Vulnerability
- Package: `idna`
- Advisory: CVE-2026-45409 / GHSA-65pc-fj4g-8rjx
- GitHub advisory: https://github.com/advisories/GHSA-65pc-fj4g-8rjx
- Relationship: transitive runtime dependency through `anyio`/`httpx`
- Vulnerable range: `< 3.15`
- Updated version: `3.17`

## Verification
- `uv run --with pip python -m pip check`
- `uv build`
- `uv sync --all-extras && ./scripts/lint`
- `./scripts/test`
- `uv run --with pip-audit pip-audit --disable-pip --no-deps -r /tmp/idna-requirement.txt --desc off`

_Conversation: https://staging.warp.dev/conversation/8252f65d-2d0e-4540-a030-90539d35ce1b_
_Run: https://oz.staging.warp.dev/runs/019e799d-25e8-76ba-9797-474712ce3893_
_This PR was generated with [Oz](https://warp.dev/oz)._
