### PR TITLE
fix: update pytest to resolve CVE-2025-71176

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -71,7 +71,7 @@ pytest==8.4.2 ; python_full_version < '3.10'
     # via
     #   pytest-asyncio
     #   pytest-xdist
-pytest==9.0.2 ; python_full_version >= '3.10'
+pytest==9.0.3 ; python_full_version >= '3.10'
     # via
     #   pytest-asyncio
     #   pytest-xdist

--- a/uv.lock
+++ b/uv.lock
@@ -779,7 +779,7 @@ wheels = [
 
 [[package]]
 name = "oz-agent-sdk"
-version = "0.4.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -804,7 +804,7 @@ dev = [
     { name = "mypy" },
     { name = "pyright" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
-    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
     { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
     { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
     { name = "pytest-xdist" },
@@ -1254,7 +1254,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and extra != 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2'",
@@ -1271,9 +1271,9 @@ dependencies = [
     { name = "pygments", marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
     { name = "tomli", marker = "python_full_version == '3.10.*' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1305,7 +1305,7 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
-    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
     { name = "typing-extensions", marker = "(python_full_version >= '3.10' and python_full_version < '3.13') or (python_full_version < '3.10' and extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2') or (python_full_version >= '3.13' and extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
@@ -1320,7 +1320,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
-    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'group-12-oz-agent-sdk-pydantic-v1' and extra == 'group-12-oz-agent-sdk-pydantic-v2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Updates `pytest` from `9.0.2` to `9.0.3` for Python `>=3.10` in `uv.lock` and `requirements-dev.lock`.
- Resolves direct development dependency alert CVE-2025-71176 / GHSA-6w46-j5rx-g56g for vulnerable tmpdir handling.
- No workarounds were applied; this is a direct lockfile update via `uv lock --upgrade-package pytest` and `uv export -o requirements-dev.lock --no-hashes`.

## Vulnerability
- Advisory: https://github.com/advisories/GHSA-6w46-j5rx-g56g
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-71176
- Dependabot alert: https://github.com/warpdotdev/oz-sdk-python/security/dependabot/12
- Vulnerable range: `< 9.0.3`
- Patched version: `9.0.3`
- Dependency relationship: direct development dependency

## Verification
- `uv pip check` passed.
- `uv build` passed.
- `./scripts/lint` passed after `./scripts/bootstrap` synced optional extras.
- `./scripts/test` passed across the configured Python/Pydantic matrix.
- `uvx pip-audit -r requirements-dev.lock` no longer reports `pytest`; it still reports unrelated existing alerts for `idna` and `pygments`.

_Conversation: https://staging.warp.dev/conversation/7e33cb0c-8fe3-4bc3-afa9-45af1e6c5599_
_Run: https://oz.staging.warp.dev/runs/019e7ec3-8877-7357-802e-2403b45e5163_
_This PR was generated with [Oz](https://warp.dev/oz)._
