### PR TITLE
fix: update Pygments to resolve CVE-2026-4539

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -779,7 +779,7 @@ wheels = [
 
 [[package]]
 name = "oz-agent-sdk"
-version = "0.4.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -1211,11 +1211,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Updates transitive dev dependency `Pygments` in `uv.lock` from `2.19.2` to `2.20.0` to resolve CVE-2026-4539 / GHSA-5239-wwwm-4pmq.
- Keeps the fix scoped to the lockfile; no generated SDK source was modified.
- Regenerating `uv.lock` also corrected the editable package metadata from `oz-agent-sdk` `0.4.0` to the project version declared in `pyproject.toml`, `0.13.0`.

## Vulnerability details
- Advisory: https://github.com/advisories/GHSA-5239-wwwm-4pmq
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-4539
- Dependabot alert: https://github.com/warpdotdev/oz-sdk-python/security/dependabot/1
- Package: `Pygments`
- Ecosystem/manifest: pip, `uv.lock`
- Relationship/scope: transitive runtime dependency in the lockfile, pulled through dev tooling (`pytest`/`rich`)
- Vulnerable range: `< 2.20.0`
- Patched version: `2.20.0`

## Verification
- `uv tree --package pygments` shows `pygments v2.20.0`.
- `pip-audit --path .venv/lib/python3.9/site-packages --skip-editable` reports `Pygments 2.20.0` with no vulnerabilities. Existing findings are for `aiohttp`, `idna`, and `pytest`, which already have open PRs.
- `./scripts/lint`
- `./scripts/test`
- `uv build`

_Conversation: https://staging.warp.dev/conversation/79ba85ba-09a8-4c6d-a123-722a0564c0b9_
_Run: https://oz.staging.warp.dev/runs/019e83e9-dd9f-779c-a21b-2eeabe0784ea_
_This PR was generated with [Oz](https://warp.dev/oz)._
