### PR TITLE
Release SDK updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,12 @@ jobs:
 
       - name: Run build
         run: uv build
+
   test:
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     timeout-minutes: 10
     name: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ aiohttp = ["aiohttp>=3.13.5", "httpx_aiohttp>=0.1.9"]
 [tool.uv]
 managed = true
 required-version = ">=0.9"
+# Security pin: idna is a transitive dependency (via httpx + anyio) and is not
+# declared above. Versions <3.15 are vulnerable to CVE-2026-45409
+# (GHSA-65pc-fj4g-8rjx), so constrain it without adding it as a direct
+# dependency. Sealed as custom code so it survives SDK regeneration.
+constraint-dependencies = ["idna>=3.15"]
 conflicts = [
     [
       { group = "pydantic-v1" },

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,9 @@ conflicts = [[
     { package = "oz-agent-sdk", group = "pydantic-v2" },
 ]]
 
+[manifest]
+constraints = [{ name = "idna", specifier = ">=3.15" }]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -617,11 +620,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Content changes

```
 pyproject.toml                                     |  5 ++
 src/oz_agent_sdk/resources/agent/agent_.py         | 30 ++++------
 .../types/agent/agent_create_params.py             | 37 +++++++++---
 src/oz_agent_sdk/types/agent/agent_response.py     | 56 +++++++++++++++---
 .../types/agent/agent_update_params.py             | 24 +++++---
 tests/api_resources/agent/test_agent_.py           | 66 +++++++++++++---------
 uv.lock                                            |  9 ++-
 7 files changed, 155 insertions(+), 72 deletions(-)
```

> **Note:** if production main has hotfixes or release commits that were never
> pulled back into staging, merging this PR will revert them. Cherry-pick them
> back to the staging repo first (see the stlc promote docs).