### PR TITLE
Pin pygments>=2.20.0 to fix CVE-2026-4539 (ReDoS)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,9 @@ aiohttp = ["aiohttp>=3.13.5", "httpx_aiohttp>=0.1.9"]
 [tool.uv]
 managed = true
 required-version = ">=0.9"
-# Security pin: idna is a transitive dependency (via httpx + anyio) and is not
-# declared above. Versions <3.15 are vulnerable to CVE-2026-45409
-# (GHSA-65pc-fj4g-8rjx), so constrain it without adding it as a direct
-# dependency. Sealed as custom code so it survives SDK regeneration.
-constraint-dependencies = ["idna>=3.15"]
+# Security pins for undeclared transitive deps, kept here so they survive SDK
+# regeneration: idna>=3.15 (CVE-2026-45409), pygments>=2.20.0 (CVE-2026-4539).
+constraint-dependencies = ["idna>=3.15", "pygments>=2.20.0"]
 conflicts = [
     [
       { group = "pydantic-v1" },

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -32,7 +32,7 @@ httpx==0.28.1
     # via
     #   oz-agent-sdk
     #   respx
-idna==3.11
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -62,7 +62,7 @@ pydantic==2.12.5
     # via oz-agent-sdk
 pydantic-core==2.41.5
     # via pydantic
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   pytest
     #   rich

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,10 @@ conflicts = [[
 ]]
 
 [manifest]
-constraints = [{ name = "idna", specifier = ">=3.15" }]
+constraints = [
+    { name = "idna", specifier = ">=3.15" },
+    { name = "pygments", specifier = ">=2.20.0" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1362,11 +1365,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Pins `pygments>=2.20.0` to resolve **CVE-2026-4539** (GHSA-5239-wwwm-4pmq), a ReDoS (catastrophic backtracking) in the archetype `AdlLexer` GUID regex affecting all versions `< 2.20.0`. The lockfile previously resolved `2.19.2`.

`pygments` is a **dev/test-only transitive dependency** (via `pytest` + `rich`); it is not a runtime dependency of the published `oz-agent-sdk`, so end users are unaffected. This clears the scanner alert for local/CI environments.

## Changes
- Add `pygments>=2.20.0` to `[tool.uv] constraint-dependencies` (alongside the existing `idna` pin), consolidated into a concise comment.
- Re-lock: `uv.lock` now resolves `pygments` to `2.20.0`.
- Regenerate `requirements-dev.lock` via `uv export -o requirements-dev.lock --no-hashes`.

## Notes
- Severity is Low (CVSS v4 1.9, local attack vector). Patched upstream in pygments 2.20.0 (released 2026-03-29).

---
Conversation: https://staging.warp.dev/conversation/410ce270-787a-4290-81f8-376499efc97b

Co-Authored-By: Oz <oz-agent@warp.dev>
